### PR TITLE
Fix sudo and gatekeeper

### DIFF
--- a/cmd/brew-barkly
+++ b/cmd/brew-barkly
@@ -74,5 +74,4 @@ if [ -n "$BARKLYTRAVIS" ] || [ -n "$USER_GITHUB" ]; then
   fi
 fi
 
-# Turning gatekeeper back on for security
-gatekeeperEnable
+cleanup

--- a/cmd/brew-barkly
+++ b/cmd/brew-barkly
@@ -5,6 +5,9 @@ cd $HOMEBREWBARKLYCMDDIR/..
 export HOMEBREWBARKLYDIR=$(pwd -P)
 . "$HOMEBREWBARKLYDIR/lib/init.sh"
 
+# Disable Gatekeeper so we can install without security prompts
+gatekeeperDisable
+
 if [ "$1" = "create" ]; then
   shift
   $HOMEBREWBARKLYDIR/lib/create.sh "$@"
@@ -70,3 +73,6 @@ if [ -n "$BARKLYTRAVIS" ] || [ -n "$USER_GITHUB" ]; then
     logk
   fi
 fi
+
+# Turning gatekeeper back on for security
+gatekeeperEnable

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Library of functions for use in project files
 
-# Portions of this file are 
+# Portions of this file are
 # Copyright (C) 2015 by Mike McQuaid
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,8 +24,8 @@
 
 abort() { STRAP_STEP="";   echo "!!! $*" >&2; exit 1; }
 alert() { STRAP_STEP="$*"; echo "!!! $*"; }
-log()   { STRAP_STEP="$*"; echo "--> $*"; }
-logn()  { STRAP_STEP="$*"; printf -- "--> %s " "$*"; }
+log()   { STRAP_STEP="$*"; sudo_init; echo "--> $*"; }
+logn()  { STRAP_STEP="$*"; sudo_init; printf -- "--> %s " "$*"; }
 logk()  { STRAP_STEP="";   echo "OK"; }
 
 checkInit() {
@@ -34,6 +34,37 @@ checkInit() {
     echo Please run from brew barkly instead.
     exit 1
   fi
+}
+
+# Copied from https://github.com/MikeMcQuaid/strap/blob/0ac782c7ddc6972f10e05cf611d4a70d46c441d8/bin/strap.sh#L55-L66
+# Initialise (or reinitialise) sudo to save unhelpful prompts later.
+sudo_init() {
+  if ! sudo -vn &>/dev/null; then
+    if [ -n "$BREWBARKLY_SUDOED_ONCE" ]; then
+      echo "--> Re-enter your password (for sudo access; sudo has timed out):"
+    else
+      echo "--> Enter your password (for sudo access):"
+    fi
+    sudo /usr/bin/true
+    BREWBARKLY_SUDOED_ONCE="1"
+  fi
+}
+
+setupSudo() {
+  # We want to ask for sudo permissions quickly when this is run.
+  sudo -k
+}
+
+gatekeeperDisable() {
+  log "Modifying gatekeeper to allow all apps to install: "
+  sudo spctl --master-disable
+  logk
+}
+
+gatekeeperEnable() {
+  log "Resetting gatekeeper to prompt for app security: "
+  sudo spctl --master-enable
+  logk
 }
 
 setupBarklyDir() {
@@ -107,3 +138,4 @@ startApps() {
 }
 
 setupBarklyDir
+setupSudo

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -137,5 +137,13 @@ startApps() {
   done < $apps
 }
 
+cleanup() {
+  # Turning gatekeeper back on for security
+  gatekeeperEnable
+  exit 2
+}
+
+trap cleanup SIGINT
+
 setupBarklyDir
 setupSudo


### PR DESCRIPTION
This pr accomplishes three things:
* Allows gatekeeper to be disabled to brew bundled apps can be installed without prompts
* Prompts for sudo at the beginning and try to keep the sudo by refreshing with every log output
* Fixes ctrl-c behavior in which our scripts continue and now cleans up gatekeeper changes as well.