### PR TITLE
Remove dotnet from rv-agent project

### DIFF
--- a/projects/rv-agent/Brewfile
+++ b/projects/rv-agent/Brewfile
@@ -2,6 +2,5 @@ tap 'caskroom/cask'
 
 brew 'xar-mackyle'
 
-cask 'dotnet'
 cask 'dotnet-sdk'
 cask 'rider'


### PR DESCRIPTION
dotnet-sdk is a superset of dotnet, and a recent change prevents both from being installed

https://github.com/Homebrew/homebrew-cask/pull/52524